### PR TITLE
Fire CLI implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 ignore
 .vscode/*
+allComments.tsv

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 ignore
+.vscode/*

--- a/DumpAllComments.py
+++ b/DumpAllComments.py
@@ -14,7 +14,7 @@ if maxResults > 100:
 
 dump = []
 
-def getComments(vidID, fName='allComments'):
+def getComments(vidID, fName: str='allComments'):
     video_id = vidID
     file_name = fName + '.tsv'
     nextPageToken = ""

--- a/DumpAllComments.py
+++ b/DumpAllComments.py
@@ -1,14 +1,11 @@
 import json
 import re
 import urllib.request
+import fire
 
 from pytube import YouTube
 
 api_key = "ENTER_YOUR_API_KEY_HERE"
-video_id = "arxGmKffjp8"
-nextPageToken = ""
-stop = False
-count = 0
 maxResults = 100 # the max is 100
 
 # 
@@ -17,31 +14,43 @@ if maxResults > 100:
 
 dump = []
 
-while not stop:
-    url = f"https://www.googleapis.com/youtube/v3/commentThreads?key={api_key}&textFormat=plainText&part=snippet&videoId={video_id}&t&maxResults={maxResults}&pageToken={nextPageToken}"
+def getComments(vidID):
+    video_id = vidID
+    nextPageToken = ""
+    stop = False
+    count = 0
 
-    json_url = urllib.request.urlopen(url)
-    data = json.loads(json_url.read())
-    nPT = 'nextPageToken'
+    while not stop:
+        url = f"https://www.googleapis.com/youtube/v3/commentThreads?key={api_key}&textFormat=plainText&part=snippet&videoId={video_id}&t&maxResults={maxResults}&pageToken={nextPageToken}"
+
+        json_url = urllib.request.urlopen(url)
+        data = json.loads(json_url.read())
+        nPT = 'nextPageToken'
+
+        # 
+        if nPT in data:
+            nextPageToken = data['nextPageToken']
+        else:
+            stop = True
+
+        # 
+        nComments = len(data['items'])
+
+        # 
+        for i in range(nComments):
+            print(f'Grabbed comment #{i + (count*maxResults)}')
+            put = f"{data['items'][i]['snippet']['topLevelComment']['snippet']['authorDisplayName']}\t{data['items'][i]['snippet']['topLevelComment']['snippet']['textDisplay']}".replace('\n'," ").replace('\r'," ")
+            dump.append(put)
+
+        # 
+        count += 1
 
     # 
-    if nPT in data:
-        nextPageToken = data['nextPageToken']
-    else:
-        stop = True
-
-    # 
-    nComments = len(data['items'])
-
-    # 
-    for i in range(nComments):
-        print(f'Grabbed comment #{i + (count*maxResults)}')
-        put = f"{data['items'][i]['snippet']['topLevelComment']['snippet']['authorDisplayName']}\t{data['items'][i]['snippet']['topLevelComment']['snippet']['textDisplay']}".replace('\n'," ").replace('\r'," ")
-        dump.append(put)
-
-    # 
-    count += 1
-
-# 
-with open("allComments.tsv", "w+", encoding='utf-8') as f:
-    f.write("\n".join(dump))
+    with open("allComments.tsv", "w+", encoding='utf-8') as f:
+        f.write("\n".join(dump))
+        
+def main():
+    fire.Fire(getComments)
+    
+if __name__ == '__main__':
+  main()

--- a/DumpAllComments.py
+++ b/DumpAllComments.py
@@ -14,8 +14,9 @@ if maxResults > 100:
 
 dump = []
 
-def getComments(vidID):
+def getComments(vidID, fName='allComments'):
     video_id = vidID
+    file_name = fName + '.tsv'
     nextPageToken = ""
     stop = False
     count = 0
@@ -46,7 +47,7 @@ def getComments(vidID):
         count += 1
 
     # 
-    with open("allComments.tsv", "w+", encoding='utf-8') as f:
+    with open(file_name, "w+", encoding='utf-8') as f:
         f.write("\n".join(dump))
         
 def main():

--- a/readme.MD
+++ b/readme.MD
@@ -5,8 +5,8 @@ Step|Task
 -|-
 1|Open [DumpAllComments.py](./DumpAllComments.py)
 2|Enter your API key that you got from the YouTube Data API v3 into `api_key = "ENTER_YOUR_API_KEY_HERE"`
-4|Run the script from a terminal: `python DumpAllComments.py [VIDEO_ID_GOES_HERE]`
-5|The default output file is `allComments.tsv`; you can specify a different file name by using the flag `--fName` as such: `python DumpAllComments.py [VIDEO_ID_GOES_HERE] --fName [FILE_NAME_GOES_HERE]`. The `.tsv` is added automatically, so just write the file name as the argument
+3|Run the script from a terminal: `python DumpAllComments.py [VIDEO_ID_GOES_HERE]`
+4|The default output file is `allComments.tsv`; you can specify a different file name by using the flag `--fName` as such: `python DumpAllComments.py [VIDEO_ID_GOES_HERE] --fName [FILE_NAME_GOES_HERE]`. The `.tsv` is added automatically, so just write the file name as the argument
 5|Check the main directory for the .tsv file (its a tabs seperated values file), which will be allComments.tsv if you did not pass in an `--fName` argument
 6|Profit
 

--- a/readme.MD
+++ b/readme.MD
@@ -5,9 +5,9 @@ Step|Task
 -|-
 1|Open [DumpAllComments.py](./DumpAllComments.py)
 2|Enter your API key that you got from the YouTube Data API v3 into `api_key = "ENTER_YOUR_API_KEY_HERE"`
-3|Past the Video URL ID into `video_id = "arxGmKffjp8"`
-4|Run the script from a terminal
-5|Check the main directory for allComments.tsv (its a tabs serperated values file)
+4|Run the script from a terminal: `python DumpAllComments.py [VIDEO_ID_GOES_HERE]`
+5|The default output file is `allComments.tsv`; you can specify a different file name by using the flag `--fName` as such: `python DumpAllComments.py [VIDEO_ID_GOES_HERE] --fName [FILE_NAME_GOES_HERE]`. The `.tsv` is added automatically, so just write the file name as the argument
+5|Check the main directory for the .tsv file (its a tabs seperated values file), which will be allComments.tsv if you did not pass in an `--fName` argument
 6|Profit
 
-Follow the first half of this video to obtain an api for YouTube Data API v3; [YouTube Data API and Python -- Part 2 by LucidProgramming](https://youtu.be/ZkYOvViSx3E)
+Follow the first half of this video to obtain an API for YouTube Data API v3; [YouTube Data API and Python -- Part 2 by LucidProgramming](https://youtu.be/ZkYOvViSx3E)


### PR DESCRIPTION
## What?
I've added Fire to the file, making the file accessible as a CLI. The user only has to open the `DumpAllComments.py` file to enter their API key.

## Why?
Giving the file a CLI interface makes it more user-friendly.

## How?
I'm using Fire to do all the big behind-the-scenes work. I moved the functional code into a function that is then called by Fire to adapt it into the CLI interface. The user now appends the video ID to the end of the script call, like so:
`python DumpAllComments.py [video ID]`
They can also specify the output file (the default is still `allComments.tsv`), like so:
`python DumpAllComments.py [video ID] --fName [file name]` (the file extension is not needed, the code adds it when taken in as the argument).